### PR TITLE
 Decode html entities before inserting the username 

### DIFF
--- a/styles/all/template/js/mention.js
+++ b/styles/all/template/js/mention.js
@@ -4,7 +4,6 @@ var decodeHTMLEntities = (function() {
     function decodeEntities (str) {
         txt.innerHTML = str;
         str = txt.value;
-        txt.value = '';
 
         return str;
     }

--- a/styles/all/template/js/mention.js
+++ b/styles/all/template/js/mention.js
@@ -1,3 +1,17 @@
+var decodeHTMLEntities = (function() {
+    var txt = document.createElement('textarea');
+
+    function decodeEntities (str) {
+        txt.innerHTML = str;
+        str = txt.value;
+        txt.value = '';
+
+        return str;
+    }
+
+    return decodeEntities;
+})();
+
 $(document).ready(function() {
     $('[name="message"]').atwho({
         at: "@",
@@ -24,6 +38,9 @@ $(document).ready(function() {
                 var regexp = new XRegExp('(\\s+|^)' + flag + '([\\p{L}-_ ]+)', 'gi');
                 var match = regexp.exec(subtext);
                 return (match != null && match[2]) ? match[2] : null;
+            },
+            beforeInsert: function(value, $li, e) {
+                return decodeHTMLEntities(value);
             }
         }
     });


### PR DESCRIPTION
Usernames containing special chars were causing trouble: for
example if someone tried to mention the user "Amy & Rory"
the script would have inserted "[mention]Amy &amp; Rory[/mention]"
(and the notification would not have been sent)