### PR TITLE
Allow digits in names

### DIFF
--- a/styles/all/template/js/mention.js
+++ b/styles/all/template/js/mention.js
@@ -21,7 +21,7 @@ $(document).ready(function() {
                 }
             },
             matcher: function(flag, subtext) {
-                var regexp = new XRegExp('(\\s+|^)' + flag + '([\\p{L}-_ ]+)', 'gi');
+                var regexp = new XRegExp('(\\s+|^)' + flag + '([\\p{L}-_ 0-9]+)', 'gi');
                 var match = regexp.exec(subtext);
                 return (match != null && match[2]) ? match[2] : null;
             }


### PR DESCRIPTION
The mention request wasn't triggered if the name to complete was including digits in the first characters. Adding 0-9 fixes the issue.